### PR TITLE
Update of index.php for Widget Sorting of Results

### DIFF
--- a/index.php
+++ b/index.php
@@ -575,12 +575,12 @@ if(!class_exists('BhittaniPlugin_kkStarRatings')) :
             global $wpdb;
             $table = $wpdb->prefix . 'postmeta';
             if(!$cat)
-                $rated_posts = $wpdb->get_results("SELECT a.ID, a.post_title, b.meta_value AS 'ratings' FROM " . $wpdb->posts . " a, $table b, $table c WHERE a.post_status='publish' AND a.ID=b.post_id AND a.ID=c.post_id AND b.meta_key='_kksr_avg' AND c.meta_key='_kksr_casts' ORDER BY b.meta_value DESC, c.meta_value DESC LIMIT $total");
+                $rated_posts = $wpdb->get_results("SELECT a.ID, a.post_title, b.meta_value AS 'ratings' FROM " . $wpdb->posts . " a, $table b, $table c WHERE a.post_status='publish' AND a.ID=b.post_id AND a.ID=c.post_id AND b.meta_key='_kksr_avg' AND c.meta_key='_kksr_casts' ORDER BY CAST(b.meta_value AS UNSIGNED) DESC, CAST(c.meta_value AS UNSIGNED) DESC LIMIT $total");
             else
             {
                 $table2 = $wpdb->prefix . 'term_taxonomy';
                 $table3 = $wpdb->prefix . 'term_relationships';
-                $rated_posts = $wpdb->get_results("SELECT a.ID, a.post_title, b.meta_value AS 'ratings' FROM " . $wpdb->posts . " a, $table b, $table2 c, $table3 d, $table e WHERE c.term_taxonomy_id=d.term_taxonomy_id AND c.term_id=$cat AND d.object_id=a.ID AND a.post_status='publish' AND a.ID=b.post_id AND a.ID=e.post_id AND b.meta_key='_kksr_avg' AND e.meta_key='_kksr_casts' ORDER BY b.meta_value DESC, e.meta_value DESC LIMIT $total");
+                $rated_posts = $wpdb->get_results("SELECT a.ID, a.post_title, b.meta_value AS 'ratings' FROM " . $wpdb->posts . " a, $table b, $table2 c, $table3 d, $table e WHERE c.term_taxonomy_id=d.term_taxonomy_id AND c.term_id=$cat AND d.object_id=a.ID AND a.post_status='publish' AND a.ID=b.post_id AND a.ID=e.post_id AND b.meta_key='_kksr_avg' AND e.meta_key='_kksr_casts' ORDER BY CAST(b.meta_value AS UNSIGNED) DESC, CAST(e.meta_value AS UNSIGNED) DESC LIMIT $total");
             }
 
             return $rated_posts;


### PR DESCRIPTION
The problem with the widget's sorting of top rated stuff is that the meta_value field is longtext. So, it doesn't properly sort numbers, specifically on the _kksr_casts field. My change is to cast those fields as UNSIGNED, in turn treating them as numbers and sorting properly.