### PR TITLE
Fix: "At least one of ratingCount or reviewCount is required."

### DIFF
--- a/index.php
+++ b/index.php
@@ -701,7 +701,7 @@ if(!class_exists('BhittaniPlugin_kkStarRatings')) :
         }
         public function grs_legend($legend, $id, $best, $score, $votes, $avg, $per)
         {
-            if(!parent::get_options('kksr_grs'))
+            if(!parent::get_options('kksr_grs') || !$score)
             {
                 return $legend;
             }


### PR DESCRIPTION
Initially if you enable the plugin with Google Rich Snippet support and
you don't have any reviews yet the markup is not valid. The
AggregateRating object is created, but it has two missing required
fields:

- Field ratingValue may not be empty.
- At least one of ratingCount or reviewCount is required.

If we have no score yet, we do not create the AggregateRating object at
all.

Closes #64