### PR TITLE
fix cold start problem for plural Suffix

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -161,7 +161,7 @@
 									<code>[total]</code>=total ratings <br />
 									<code>[avg]</code>=average <br />
 									<code>[per]</code>=percentage <br />
-									<code>[s]</code>=for plural vs singular of votes occurred <br />
+									<code>[suffix]</code>=for plural vs singular of votes occurred <br />
 									<strong>NOTE</strong> <br />
 									<code>[total]</code> and <code>[avg]</code> is mandatory for Google Rich Snippets to work
 								',
@@ -170,7 +170,7 @@
 			));
       BhittaniPlugin_AdminMarkup::input(array(
 				'title' => 'Plural Suffix for number of Votes',
-				'description' => 'Adjust the Suffix for <code>[s]</code> placeholder. (e.G. "15 votes" [English] or "15 Bewertungen" [German].)',
+				'description' => 'Adjust the Suffix for <code>[suffix]</code> placeholder. (e.G. "15 votes" [English] or "15 Bewertungen" [German].)',
 				'field' => 'kksr_suffix_votes',
 				'value' => get_option('kksr_suffix_votes')
 			));

--- a/index.php
+++ b/index.php
@@ -152,7 +152,8 @@ if(!class_exists('BhittaniPlugin_kkStarRatings')) :
             $opt_show_in_pages = 0; // 1|0
             $opt_unique = 0; // 1|0
             $opt_position = 'top-left'; // 'top-left', 'top-right', 'bottom-left', 'bottom-right'
-            $opt_legend = '[avg] ([per]) [total] vote[s]'; // [total]=total ratings, [avg]=average, [per]=percentage [s]=singular/plural
+	        $kksr_sufix_votes = 's'; // 's' in english for voteS
+            $opt_legend = '[avg] ([per]) [total] vote[suffix]'; // [total]=total ratings, [avg]=average, [per]=percentage [suffix]=singular/plural
             $opt_init_msg = 'Rate this post'; // string
             $opt_column = 1; // 1|0
 
@@ -165,6 +166,7 @@ if(!class_exists('BhittaniPlugin_kkStarRatings')) :
             $Options['kksr_show_in_pages'] = isset($Old_plugin['show_in_pages']) ? $Old_plugin['show_in_pages'] : $opt_show_in_pages;
             $Options['kksr_unique'] = isset($Old_plugin['unique']) ? $Old_plugin['unique'] : $opt_unique;
             $Options['kksr_position'] = isset($Old_plugin['position']) ? $Old_plugin['position'] : $opt_position;
+	        $Options['kksr_suffix_votes'] = isset($Old_plugin['kksr_suffix_votes']) ? $Old_plugin['kksr_suffix_votes'] : $kksr_sufix_votes;
             $Options['kksr_legend'] = isset($Old_plugin['legend']) ? $Old_plugin['legend'] : $opt_legend;
             $Options['kksr_init_msg'] = isset($Old_plugin['init_msg']) ? $Old_plugin['init_msg'] : $opt_init_msg;
             $Options['kksr_column'] = isset($Old_plugin['column']) ? $Old_plugin['column'] : $opt_column;
@@ -213,7 +215,6 @@ if(!class_exists('BhittaniPlugin_kkStarRatings')) :
                 $Options['kksr_stars_yellow'] = 0;
                 $Options['kksr_stars_orange'] = 0;
                 $Options['kksr_js_fuelspeed'] = 400;
-                $Options['kksr_sufix_votes'] = 's';
                 $Options['kksr_js_thankyou'] = 'Thank you for your vote';
                 $Options['kksr_js_error'] = 'An error occurred';
                 $Options['kksr_tooltip'] = 0;
@@ -704,7 +705,7 @@ if(!class_exists('BhittaniPlugin_kkStarRatings')) :
             $leg = str_replace('[total]', '<span itemprop="ratingCount">'.$votes.'</span>', $legend);
             $leg = str_replace('[avg]', '<span itemprop="ratingValue">'.$avg.'</span>', $leg);
             $leg = str_replace('[per]',  $per .'%', $leg);
-            $leg = str_replace('[s]', $votes == 1 ? '' : $pluralSuffix, $leg);
+            $leg = str_replace('[suffix]', $votes == 1 ? '' : $pluralSuffix, $leg);
             $leg = str_replace('[best]', $best, $leg);
 
             return $leg;
@@ -736,6 +737,9 @@ if(!class_exists('BhittaniPlugin_kkStarRatings')) :
 
     // Setup
     register_activation_hook(__FILE__, array($kkStarRatings_obj, 'activate'));
+
+    //Uninstall
+	// TODO: include 'register_uninstall_hook() '
 
     // Scripts
     add_action('wp_enqueue_scripts', array($kkStarRatings_obj, 'js'));


### PR DESCRIPTION
Last week, there was a pull request for the suffix of vote[s].
But... There was no default value set during installation of the PlugIn.
Here is the fix.

What changed:
- change shortcode from [s] to [suffix]
- Update for register_activation_hook

An Update on https://wordpress.org/plugins/kk-star-ratings/ would be nice.