### PR TITLE
Remove extra spaces in the legend

### DIFF
--- a/views/legend.php
+++ b/views/legend.php
@@ -1,8 +1,4 @@
 <div class="kksr-legend" style="<?php echo $count ? '' : 'display: none; ' ?>line-height:<?php echo $size; ?>px;font-size:<?php echo $size/1.5; ?>px">
-    <div class="kksr-legend-score">
-        <?php echo apply_filters('kksr_score', $score); ?>
-    </div>
-    <div class="kksr-legend-meta">
-        <?php echo apply_filters('kksr_count', $count); ?>
-    </div>
+    <div class="kksr-legend-score"><?php echo apply_filters('kksr_score', $score); ?></div>
+    <div class="kksr-legend-meta"><?php echo apply_filters('kksr_count', $count); ?></div>
 </div>


### PR DESCRIPTION
This affects how the spacing looks like on the frontend.

This is how the rating looks with custom styles and the extra spaces in the markup
![image](https://user-images.githubusercontent.com/1785641/62117583-7d762000-b2bc-11e9-8c19-a144c9f7c00a.png)

This is how the rating looks with custom styles but without extra spaces in the markup
![image](https://user-images.githubusercontent.com/1785641/62117637-9088f000-b2bc-11e9-9470-c033696087c7.png)
