### PR TITLE
Unique votes disable interface

### DIFF
--- a/public/js/kk-star-ratings.js
+++ b/public/js/kk-star-ratings.js
@@ -44,7 +44,7 @@ jQuery(document).ready(function ($) {
                     $score.text(response.score);
                     $count.text(response.count);
                     $legend.show();
-                    if (response.block) {
+                    if (response.disable) {
                         $el.addClass('kksr-disable');
                     }
                     console.log('success', response);

--- a/src/ajax.php
+++ b/src/ajax.php
@@ -71,7 +71,7 @@ add_action('wp_ajax_nopriv_'.KKSR_SLUG, KKSR_NAMESPACE.'ajax'); function ajax()
 
     status_header(201);
 
-    $disable = false;
+    $disable = in_array('unique', getOption('strategies'));
     $count = apply_filters('kksr_count', $count);
     $score = apply_filters('kksr_score', calculateScore($ratings, $count, getOption('stars')));
     $percentage = apply_filters('kksr_percentage', calculatePercentage($ratings, $count));


### PR DESCRIPTION
Unique votes didn't disable interface. User shouldn't be able to hover over stars, when he already voted.
Changes: Ajax.php recognizes when it should be disabled. Javascript was checking wrong variable from request.