### PR TITLE
Fix multiple voting for a same ip issue.

### DIFF
--- a/src/post.php
+++ b/src/post.php
@@ -184,7 +184,7 @@ function vote_post($score, $best, $id, $slug)
 
     $ip = md5($_SERVER['REMOTE_ADDR']);
 
-    update_post_meta($id, meta_prefix('ref'), $ip, $ip);
+    add_post_meta($id, meta_prefix('ref'), $ip);
 }
 
 add_action('wp_head', __NAMESPACE__.'\structured_data');


### PR DESCRIPTION
There is an issue with IP restricted vote. Currently only the first voter cannot vote multiple times, all the others can vote as many times they want.

**Why is that ?** 
Right now you are using the function `update_post_meta($id, meta_prefix('ref'), $ip, $ip);`.
Expected behavior of `update_post_meta` is to add a new post_meta if there is not, or update a post_meta if there is already one for the same post_id and meta_name. Though, you are using the fourth parameter by passing him `$ip`, which modify the default behavior as `update_post_meta` will then only update a post meta which current value is equal to this fourth parameter.
As you are using the same parameter for both third and fourth parameter, you are actually only updating post metas whose current value is the same as the new value. So you are actually not updating anything.
Also, the fact of using the fourth parameter disable the insertion of a new post_meta with a different ip address.

**Easiest solution**
For me the easiest solution seems to be using `add_post_meta` instead of `update_post_meta`. This will create a new `ref` meta for each new voter. Also, their will never be two `ref` for a same ip because a new ref is only inserted when a voter do vote, which is precisely restricted by the fact a `ref` exist for this ip.