### PR TITLE
Add kkstarratings() to init after Ajax request

### DIFF
--- a/public/js/kk-star-ratings.js
+++ b/public/js/kk-star-ratings.js
@@ -64,4 +64,14 @@ jQuery(document).ready(function ($) {
     $('.kk-star-ratings').each(function () {
         apply($(this))
     });
+    
+    // Allow to be called after being load via Ajax
+    window.kkstarratings = function(el){
+	    $(el).each(function () {
+		   	if(!el.selector === '.kk-star-ratings'){
+			   	return false;
+		   	}
+	      	apply($(this))
+	    });
+    };
 });


### PR DESCRIPTION
A user of my [Ajax Load More plugin](https://wordpress.org/plugins/ajax-load-more/) needed to be able to initiate your plugin after a post was loaded via Ajax.

I added this window scoped function that allows KK Star Rating to initiated from a callback.

```
window.almComplete = function(alm){
	var ratings = jQuery('.kk-star-ratings', alm.el);
	if(typeof kkstarratings === 'function' && ratings){
		window.kkstarratings(ratings);
	}
}
```